### PR TITLE
feat: add decay_type field following substrates pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,7 @@ jobs:
             VITE_CLARITY_ID=${{ secrets.VITE_CLARITY_ID }}
 
       - name: Install Trivy CLI
-        run: |
-          TRIVY_VERSION="v0.56.2"
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
-          trivy --version
+        run: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Trivy fs
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,13 @@ ARG VITE_SITE_URL
 ARG VITE_PUBLIC_STORAGE_BASE_URL
 ARG VITE_CLARITY_ID
 
-ENV VITE_API_URL=${VITE_API_URL}
-ENV VITE_API_KEY=${VITE_API_KEY}
-ENV VITE_ROBOTS=${VITE_ROBOTS}
-ENV VITE_SITE_URL=${VITE_SITE_URL}
-ENV VITE_PUBLIC_STORAGE_BASE_URL=${VITE_PUBLIC_STORAGE_BASE_URL}
-ENV VITE_CLARITY_ID=${VITE_CLARITY_ID}
-
-RUN npm run build
+RUN VITE_API_URL=${VITE_API_URL} \
+    VITE_API_KEY=${VITE_API_KEY} \
+    VITE_ROBOTS=${VITE_ROBOTS} \
+    VITE_SITE_URL=${VITE_SITE_URL} \
+    VITE_PUBLIC_STORAGE_BASE_URL=${VITE_PUBLIC_STORAGE_BASE_URL} \
+    VITE_CLARITY_ID=${VITE_CLARITY_ID} \
+    npm run build
 
 # PROD
 FROM nginx:1.29.3-alpine-slim AS prod
@@ -47,7 +46,8 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 
-RUN apk add --no-cache curl=8.14.1-r2
+RUN apk upgrade --no-cache && \
+    apk add --no-cache curl=8.14.1-r2
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -fsS http://localhost:80/pt || exit 1

--- a/src/api/species/index.ts
+++ b/src/api/species/index.ts
@@ -90,7 +90,12 @@ export const selectSpeciesFamily = async (search?: string, signal?: AbortControl
   return resposta.data;
 };
 
-export type SpeciesDomainSelectType = "growth_form" | "nutrition_mode" | "substrate" | "habitat";
+export type SpeciesDomainSelectType =
+  | "growth_form"
+  | "nutrition_mode"
+  | "substrate"
+  | "decay_type"
+  | "habitat";
 
 export const selectSpeciesDomain = async (
   domain: SpeciesDomainSelectType,

--- a/src/api/species/types/ISpecie.ts
+++ b/src/api/species/types/ISpecie.ts
@@ -58,6 +58,7 @@ export interface SpeciesCharacteristics {
   size_cm?: number | null;
   species_id?: number;
   substrates?: SpeciesLocalizedOption[];
+  decay_types?: SpeciesLocalizedOption[];
   cultivation_possible: boolean | null;
   iucn_assessment_url: string | null;
   iucn_assessment_year: string | null;

--- a/src/components/combobox-async.tsx
+++ b/src/components/combobox-async.tsx
@@ -24,23 +24,23 @@ export type ComboboxOption = {
 };
 
 type ComboboxAsyncBaseProps = {
-  fetchOptions: (search: string, signal: AbortController["signal"]) => Promise<ComboboxOption[]>;
+  fetchOptions: (_search: string, _signal: AbortController["signal"]) => Promise<ComboboxOption[]>;
   placeholder?: string;
   variant?: "dark" | "light";
   initialKnownOptions?: ComboboxOption[];
-  renderOptionExtra?: (option: ComboboxOption) => React.ReactNode;
+  renderOptionExtra?: (_option: ComboboxOption) => React.ReactNode;
 };
 
 type ComboboxAsyncSingleProps = ComboboxAsyncBaseProps & {
   multiple?: false;
   value: string | number | null;
-  onSelect?: (id: string | number | null) => void;
+  onSelect?: (_id: string | number | null) => void;
 };
 
 type ComboboxAsyncMultipleProps = ComboboxAsyncBaseProps & {
   multiple: true;
   value: Array<string | number>;
-  onSelect?: (ids: Array<string | number>) => void;
+  onSelect?: (_ids: Array<string | number>) => void;
 };
 
 export type ComboboxAsyncProps = ComboboxAsyncSingleProps | ComboboxAsyncMultipleProps;

--- a/src/components/use-initial-combobox-options.ts
+++ b/src/components/use-initial-combobox-options.ts
@@ -10,7 +10,7 @@ import type { ComboboxOption } from "./combobox-async";
  */
 export function useInitialComboboxOptions<T>(
   items: T[] | undefined,
-  mapper: (item: T) => ComboboxOption
+  mapper: (_item: T) => ComboboxOption
 ): ComboboxOption[] {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return React.useMemo(() => (items ?? []).map(mapper), []);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -231,7 +231,8 @@
         "occurrence": "Biogeographic regions of occurrence",
         "growth_forms": "Growth form",
         "nutrition_modes": "Lifestyle",
-        "substrates": "Substrate"
+        "substrates": "Substrate",
+        "decay_types": "Decay type"
       },
       "taxonomy": {
         "kingdom": "Kingdom",
@@ -329,6 +330,7 @@
       "growth_forms": "Growth form",
       "nutrition_modes": "Lifestyle",
       "substrates": "Substrate",
+      "decay_types": "Decay type",
       "habitats": "Biomes",
       "domain_multi_placeholder": "Select one or more options",
       "colors": "Colors",
@@ -498,6 +500,7 @@
       "species_edit_field_growth_forms": "Growth form",
       "species_edit_field_nutrition_modes": "Lifestyle",
       "species_edit_field_substrates": "Substrate",
+      "species_edit_field_decay_types": "Decay type",
       "species_edit_field_habitats": "Biomes",
       "species_edit_field_colors_pt": "Colors (PT)",
       "species_edit_field_colors": "Colors (EN)",
@@ -787,10 +790,12 @@
       "field_growth_forms": "Growth form",
       "field_nutrition_modes": "Lifestyle",
       "field_substrates": "Substrate",
+      "field_decay_types": "Decay type",
       "field_habitats": "Biome",
       "field_growth_form_ids": "Growth form",
       "field_nutrition_mode_ids": "Lifestyle",
       "field_substrate_ids": "Substrate",
+      "field_decay_type_ids": "Decay type",
       "field_habitat_ids": "Biome",
       "field_colors": "Colors (EN)",
       "field_colors_pt": "Colors (PT)",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -231,7 +231,8 @@
         "occurrence": "Regiões biogeográficas de ocorrência",
         "growth_forms": "Forma de crescimento",
         "nutrition_modes": "Estilo de vida",
-        "substrates": "Substrato"
+        "substrates": "Substrato",
+        "decay_types": "Tipo de decomposição"
       },
       "taxonomy": {
         "kingdom": "Reino",
@@ -329,6 +330,7 @@
       "growth_forms": "Forma de crescimento",
       "nutrition_modes": "Estilo de vida",
       "substrates": "Substrato",
+      "decay_types": "Tipo de decomposição",
       "habitats": "Biomas",
       "domain_multi_placeholder": "Selecione uma ou mais opções",
       "colors": "Cores",
@@ -497,6 +499,7 @@
       "species_edit_field_growth_forms": "Forma de crescimento",
       "species_edit_field_nutrition_modes": "Estilo de vida",
       "species_edit_field_substrates": "Substrato",
+      "species_edit_field_decay_types": "Tipo de decomposição",
       "species_edit_field_habitats": "Biomas",
       "species_edit_field_colors_pt": "Cores (PT)",
       "species_edit_field_colors": "Cores (EN)",
@@ -787,10 +790,12 @@
       "field_growth_forms": "Forma de crescimento",
       "field_nutrition_modes": "Estilo de vida",
       "field_substrates": "Substrato",
+      "field_decay_types": "Tipo de decomposição",
       "field_habitats": "Bioma",
       "field_growth_form_ids": "Forma de crescimento",
       "field_nutrition_mode_ids": "Estilo de vida",
       "field_substrate_ids": "Substrato",
+      "field_decay_type_ids": "Tipo de decomposição",
       "field_habitat_ids": "Bioma",
       "field_colors": "Cores (EN)",
       "field_colors_pt": "Cores (PT)",

--- a/src/pages/panel/species-create/index.tsx
+++ b/src/pages/panel/species-create/index.tsx
@@ -76,7 +76,10 @@ function PanelSpeciesCreatePage() {
     () => pickEditableFields(["growth_forms", "size_cm", "colors_pt", "colors", "nutrition_modes"]),
     [pickEditableFields]
   );
-  const substrateFields = useMemo(() => pickEditableFields(["substrates"]), [pickEditableFields]);
+  const substrateFields = useMemo(
+    () => pickEditableFields(["substrates", "decay_types"]),
+    [pickEditableFields]
+  );
   const habitatFields = useMemo(() => pickEditableFields(["habitats"]), [pickEditableFields]);
   const distributionFields = useMemo(
     () =>

--- a/src/pages/panel/species-edit/constants.ts
+++ b/src/pages/panel/species-edit/constants.ts
@@ -133,6 +133,13 @@ export const SPECIES_EDIT_FIELDS: SpeciesEditFieldConfig[] = [
     domain: "substrate",
   },
   {
+    name: "decay_types",
+    labelKey: "panel_page.species_edit_field_decay_types",
+    placeholderKey: "panel_page.species_edit_domain_multi_placeholder",
+    inputType: "domain-multi-async",
+    domain: "decay_type",
+  },
+  {
     name: "habitats",
     labelKey: "panel_page.species_edit_field_habitats",
     placeholderKey: "panel_page.species_edit_domain_multi_placeholder",
@@ -269,6 +276,7 @@ export const SPECIES_EDIT_FORM_INITIAL_VALUES: SpeciesEditFormValues = {
   growth_forms: [],
   nutrition_modes: [],
   substrates: [],
+  decay_types: [],
   habitats: [],
   colors_pt: "",
   colors: "",

--- a/src/pages/panel/species-edit/hooks/use-species-edit-form.ts
+++ b/src/pages/panel/species-edit/hooks/use-species-edit-form.ts
@@ -75,6 +75,11 @@ export function useSpeciesEditForm({ species, isViewMode, locale }: UseSpeciesEd
         label_pt: item.label_pt,
         label_en: item.label_en,
       })),
+      decay_type: (speciesData.species_characteristics?.decay_types ?? []).map((item) => ({
+        value: item.id,
+        label_pt: item.label_pt,
+        label_en: item.label_en,
+      })),
       habitat: (speciesData.species_characteristics?.habitats ?? []).map((item) => ({
         value: item.id,
         label_pt: item.label_pt,

--- a/src/pages/panel/species-edit/index.tsx
+++ b/src/pages/panel/species-edit/index.tsx
@@ -32,7 +32,7 @@ const TROPHIC_FIELDS_ORDER = [
   "colors",
   "nutrition_modes",
 ] as const;
-const SUBSTRATE_FIELDS_ORDER = ["substrates"] as const;
+const SUBSTRATE_FIELDS_ORDER = ["substrates", "decay_types"] as const;
 const HABITAT_FIELDS_ORDER = ["habitats"] as const;
 const DISTRIBUTION_FIELDS_ORDER = [
   "distributions",

--- a/src/pages/panel/species-edit/schema.ts
+++ b/src/pages/panel/species-edit/schema.ts
@@ -39,6 +39,7 @@ export function createSpeciesEditSchema(t: TFunction) {
     growth_forms: z.array(z.number()).catch([]),
     nutrition_modes: z.array(z.number()).catch([]),
     substrates: z.array(z.number()).catch([]),
+    decay_types: z.array(z.number()).catch([]),
     habitats: z.array(z.number()).catch([]),
     colors_pt: z.string(),
     colors: z.string(),

--- a/src/pages/panel/species-edit/types.ts
+++ b/src/pages/panel/species-edit/types.ts
@@ -19,6 +19,7 @@ export type SpeciesEditFormValues = {
   growth_forms: number[];
   nutrition_modes: number[];
   substrates: number[];
+  decay_types: number[];
   habitats: number[];
   colors_pt: string;
   colors: string;

--- a/src/pages/panel/species-edit/utils.ts
+++ b/src/pages/panel/species-edit/utils.ts
@@ -105,6 +105,7 @@ export function createSpeciesEditFormDefaults(speciesData: ISpecie): SpeciesEdit
       (item) => item.id
     ),
     substrates: (speciesData.species_characteristics?.substrates ?? []).map((item) => item.id),
+    decay_types: (speciesData.species_characteristics?.decay_types ?? []).map((item) => item.id),
     habitats: (speciesData.species_characteristics?.habitats ?? []).map((item) => item.id),
     colors_pt: speciesData.species_characteristics?.colors_pt ?? "",
     colors: speciesData.species_characteristics?.colors ?? "",
@@ -211,6 +212,7 @@ function normalizeForCompare(name: SpeciesEditFieldConfig["name"], value: unknow
     name === "growth_forms" ||
     name === "nutrition_modes" ||
     name === "substrates" ||
+    name === "decay_types" ||
     name === "habitats" ||
     name === "similar_species_ids" ||
     name === "distributions"
@@ -382,6 +384,10 @@ export function buildDomainViewValueMap(
     ),
     substrates: getLocalizedOptionLabels(
       speciesData.species_characteristics?.substrates,
+      isPtLanguage
+    ),
+    decay_types: getLocalizedOptionLabels(
+      speciesData.species_characteristics?.decay_types,
       isPtLanguage
     ),
     habitats: getLocalizedOptionLabels(speciesData.species_characteristics?.habitats, isPtLanguage),

--- a/src/pages/species-request/components/review-step.tsx
+++ b/src/pages/species-request/components/review-step.tsx
@@ -21,11 +21,18 @@ export function ReviewStep({ values, selectedFileCount }: ReviewStepProps) {
       selectSpeciesDomain("growth_form"),
       selectSpeciesDomain("nutrition_mode"),
       selectSpeciesDomain("substrate"),
+      selectSpeciesDomain("decay_type"),
       selectSpeciesDomain("habitat"),
     ])
-      .then(([growthForms, nutritionModes, substrates, habitats]) => {
+      .then(([growthForms, nutritionModes, substrates, decayTypes, habitats]) => {
         if (!active) return;
-        const merged = [...growthForms, ...nutritionModes, ...substrates, ...habitats];
+        const merged = [
+          ...growthForms,
+          ...nutritionModes,
+          ...substrates,
+          ...decayTypes,
+          ...habitats,
+        ];
         const next: Record<string, string> = {};
         for (const option of merged) {
           next[String(option.value)] = isPt ? option.label_pt : option.label_en;
@@ -60,6 +67,7 @@ export function ReviewStep({ values, selectedFileCount }: ReviewStepProps) {
   const hasGrowthForms = values.growth_forms.length > 0;
   const hasNutritionModes = values.nutrition_modes.length > 0;
   const hasSubstrates = values.substrates.length > 0;
+  const hasDecayTypes = values.decay_types.length > 0;
   const hasHabitats = values.habitats.length > 0;
   const hasColors = Boolean(values.colors?.trim());
   const hasCultivation = Boolean(values.cultivation?.trim());
@@ -86,6 +94,7 @@ export function ReviewStep({ values, selectedFileCount }: ReviewStepProps) {
     hasGrowthForms ||
     hasNutritionModes ||
     hasSubstrates ||
+    hasDecayTypes ||
     hasHabitats ||
     hasColors ||
     hasCultivation ||
@@ -133,6 +142,11 @@ export function ReviewStep({ values, selectedFileCount }: ReviewStepProps) {
             {hasSubstrates ? (
               <p>
                 {t("species_request.substrates")}: {formatDomainValues(values.substrates)}
+              </p>
+            ) : null}
+            {hasDecayTypes ? (
+              <p>
+                {t("species_request.decay_types")}: {formatDomainValues(values.decay_types)}
               </p>
             ) : null}
             {hasHabitats ? (

--- a/src/pages/species-request/components/species-data-step.tsx
+++ b/src/pages/species-request/components/species-data-step.tsx
@@ -45,7 +45,108 @@ export function SpeciesDataStep({ form }: SpeciesDataStepProps) {
 
   return (
     <section className="space-y-4">
-      <StepSection title={t("species_request.section_characteristics")}>
+      <StepSection title={t("species_request.section_luminescence")}>
+        <FormField
+          control={form.control}
+          name="luminescent_parts"
+          render={({ field }) => {
+            const selected = field.value ?? {};
+            const togglePart = (id: (typeof LUMINESCENT_PART_OPTIONS)[number]["id"]) => {
+              const next = { ...selected };
+              if (next[id] && next[id] !== "none") {
+                next[id] = "none";
+                field.onChange(next);
+                return;
+              }
+              next[id] = "add";
+              field.onChange(next);
+            };
+            const setAction = (
+              id: (typeof LUMINESCENT_PART_OPTIONS)[number]["id"],
+              action: "none" | "add" | "remove"
+            ) => {
+              field.onChange({
+                ...selected,
+                [id]: action,
+              });
+            };
+
+            return (
+              <FormItem>
+                <FormLabel>{t("species_request.luminescent_parts")}</FormLabel>
+                <p className="text-xs text-white/70">
+                  {t("species_request.luminescent_parts_help")}
+                </p>
+                <FormControl>
+                  <div className="grid gap-2 pt-1 md:grid-cols-2">
+                    {LUMINESCENT_PART_OPTIONS.map((option) => {
+                      const action = selected[option.id];
+                      const isSelected = action === "add" || action === "remove";
+                      return (
+                        <div
+                          key={option.id}
+                          className="rounded-md border border-white/15 bg-black/20 p-2"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <span className="text-sm">{t(option.labelKey)}</span>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant={isSelected ? "default" : "outline"}
+                              onClick={() => togglePart(option.id)}
+                              className={
+                                isSelected ? "bg-slate-200 text-black hover:bg-slate-300" : ""
+                              }
+                            >
+                              {isSelected
+                                ? t("species_request.lum_part_toggle_clear")
+                                : t("species_request.lum_part_toggle_enable")}
+                            </Button>
+                          </div>
+
+                          {isSelected ? (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setAction(option.id, "add")}
+                                className={
+                                  action === "add"
+                                    ? "border-emerald-500 bg-emerald-500 text-white hover:bg-emerald-600 hover:text-white"
+                                    : "border-emerald-500/80 text-emerald-400 hover:bg-emerald-500/10 hover:text-emerald-300"
+                                }
+                              >
+                                {t("species_page.lumm.yes")}
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setAction(option.id, "remove")}
+                                className={
+                                  action === "remove"
+                                    ? "border-red-500 bg-red-500 text-white hover:bg-red-600 hover:text-white"
+                                    : "border-red-500/80 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+                                }
+                              >
+                                {t("species_page.lumm.no")}
+                              </Button>
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            );
+          }}
+        />
+      </StepSection>
+
+      <StepSection title={t("species_page.sections.characteristics_trophic")}>
         <div className="grid gap-4 md:grid-cols-2">
           <FormField
             control={form.control}
@@ -85,50 +186,6 @@ export function SpeciesDataStep({ form }: SpeciesDataStepProps) {
               </FormItem>
             )}
           />
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2">
-          <FormField
-            control={form.control}
-            name="substrates"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t("species_request.substrates")}</FormLabel>
-                <FormControl>
-                  <DomainComboboxAsync
-                    domain="substrate"
-                    multiple
-                    value={field.value ?? []}
-                    onSelect={field.onChange}
-                    placeholder={t("species_request.domain_multi_placeholder")}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="habitats"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t("species_request.habitats")}</FormLabel>
-                <FormControl>
-                  <DomainComboboxAsync
-                    domain="habitat"
-                    multiple
-                    value={field.value ?? []}
-                    onSelect={field.onChange}
-                    placeholder={t("species_request.domain_multi_placeholder")}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2">
           <FormField
             control={form.control}
             name="size_cm"
@@ -161,6 +218,73 @@ export function SpeciesDataStep({ form }: SpeciesDataStepProps) {
                     value={field.value ?? ""}
                     onChange={field.onChange}
                     placeholder={t("species_request.colors_placeholder")}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </StepSection>
+
+      <StepSection title={t("species_page.sections.characteristics_substrate")}>
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="substrates"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("species_request.substrates")}</FormLabel>
+                <FormControl>
+                  <DomainComboboxAsync
+                    domain="substrate"
+                    multiple
+                    value={field.value ?? []}
+                    onSelect={field.onChange}
+                    placeholder={t("species_request.domain_multi_placeholder")}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="decay_types"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("species_request.decay_types")}</FormLabel>
+                <FormControl>
+                  <DomainComboboxAsync
+                    domain="decay_type"
+                    multiple
+                    value={field.value ?? []}
+                    onSelect={field.onChange}
+                    placeholder={t("species_request.domain_multi_placeholder")}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </StepSection>
+
+      <StepSection title={t("species_page.sections.characteristics_habitat")}>
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="habitats"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("species_request.habitats")}</FormLabel>
+                <FormControl>
+                  <DomainComboboxAsync
+                    domain="habitat"
+                    multiple
+                    value={field.value ?? []}
+                    onSelect={field.onChange}
+                    placeholder={t("species_request.domain_multi_placeholder")}
                   />
                 </FormControl>
                 <FormMessage />
@@ -305,107 +429,6 @@ export function SpeciesDataStep({ form }: SpeciesDataStepProps) {
             )}
           />
         ) : null}
-      </StepSection>
-
-      <StepSection title={t("species_request.section_luminescence")}>
-        <FormField
-          control={form.control}
-          name="luminescent_parts"
-          render={({ field }) => {
-            const selected = field.value ?? {};
-            const togglePart = (id: (typeof LUMINESCENT_PART_OPTIONS)[number]["id"]) => {
-              const next = { ...selected };
-              if (next[id] && next[id] !== "none") {
-                next[id] = "none";
-                field.onChange(next);
-                return;
-              }
-              next[id] = "add";
-              field.onChange(next);
-            };
-            const setAction = (
-              id: (typeof LUMINESCENT_PART_OPTIONS)[number]["id"],
-              action: "none" | "add" | "remove"
-            ) => {
-              field.onChange({
-                ...selected,
-                [id]: action,
-              });
-            };
-
-            return (
-              <FormItem>
-                <FormLabel>{t("species_request.luminescent_parts")}</FormLabel>
-                <p className="text-xs text-white/70">
-                  {t("species_request.luminescent_parts_help")}
-                </p>
-                <FormControl>
-                  <div className="grid gap-2 pt-1 md:grid-cols-2">
-                    {LUMINESCENT_PART_OPTIONS.map((option) => {
-                      const action = selected[option.id];
-                      const isSelected = action === "add" || action === "remove";
-                      return (
-                        <div
-                          key={option.id}
-                          className="rounded-md border border-white/15 bg-black/20 p-2"
-                        >
-                          <div className="flex flex-wrap items-center justify-between gap-2">
-                            <span className="text-sm">{t(option.labelKey)}</span>
-                            <Button
-                              type="button"
-                              size="sm"
-                              variant={isSelected ? "default" : "outline"}
-                              onClick={() => togglePart(option.id)}
-                              className={
-                                isSelected ? "bg-slate-200 text-black hover:bg-slate-300" : ""
-                              }
-                            >
-                              {isSelected
-                                ? t("species_request.lum_part_toggle_clear")
-                                : t("species_request.lum_part_toggle_enable")}
-                            </Button>
-                          </div>
-
-                          {isSelected ? (
-                            <div className="mt-2 flex flex-wrap gap-2">
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="outline"
-                                onClick={() => setAction(option.id, "add")}
-                                className={
-                                  action === "add"
-                                    ? "border-emerald-500 bg-emerald-500 text-white hover:bg-emerald-600 hover:text-white"
-                                    : "border-emerald-500/80 text-emerald-400 hover:bg-emerald-500/10 hover:text-emerald-300"
-                                }
-                              >
-                                {t("species_page.lumm.yes")}
-                              </Button>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="outline"
-                                onClick={() => setAction(option.id, "remove")}
-                                className={
-                                  action === "remove"
-                                    ? "border-red-500 bg-red-500 text-white hover:bg-red-600 hover:text-white"
-                                    : "border-red-500/80 text-red-400 hover:bg-red-500/10 hover:text-red-300"
-                                }
-                              >
-                                {t("species_page.lumm.no")}
-                              </Button>
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            );
-          }}
-        />
       </StepSection>
 
       <StepSection title={t("species_request.section_description")}>

--- a/src/pages/species-request/index.tsx
+++ b/src/pages/species-request/index.tsx
@@ -78,6 +78,7 @@ export default function SpeciesRequestPage() {
           growth_forms: z.array(z.number()).catch([]),
           nutrition_modes: z.array(z.number()).catch([]),
           substrates: z.array(z.number()).catch([]),
+          decay_types: z.array(z.number()).catch([]),
           habitats: z.array(z.number()).catch([]),
           luminescent_parts: z.record(
             z.enum(["mycelium", "basidiome", "stipe", "pileus", "lamellae", "spores"]),
@@ -124,6 +125,7 @@ export default function SpeciesRequestPage() {
       growth_forms: [],
       nutrition_modes: [],
       substrates: [],
+      decay_types: [],
       habitats: [],
       luminescent_parts: {
         mycelium: "none",

--- a/src/pages/species-request/types.ts
+++ b/src/pages/species-request/types.ts
@@ -22,6 +22,7 @@ export type SpeciesRequestFormValues = {
   growth_forms: number[];
   nutrition_modes: number[];
   substrates: number[];
+  decay_types: number[];
   habitats: number[];
   luminescent_parts: LuminescentPartsForm;
 };

--- a/src/pages/species/components/characteristicsCard.tsx
+++ b/src/pages/species/components/characteristicsCard.tsx
@@ -65,6 +65,7 @@ export function CharacteristicsCard({
   );
   const growthFormsValue = getLocalizedOptionLabels(characteristics?.growth_forms, isPtLanguage);
   const substratesValue = getLocalizedOptionLabels(characteristics?.substrates, isPtLanguage);
+  const decayTypesValue = getLocalizedOptionLabels(characteristics?.decay_types, isPtLanguage);
   const habitatsValue = getLocalizedOptionLabels(characteristics?.habitats, isPtLanguage);
 
   const distributionsValue = species?.distributions?.length
@@ -112,6 +113,10 @@ export function CharacteristicsCard({
         {
           label: t("species_page.fields.substrates"),
           value: withNoInformationFallback(substratesValue, noInformationLabel),
+        },
+        {
+          label: t("species_page.fields.decay_types"),
+          value: withNoInformationFallback(decayTypesValue, noInformationLabel),
         },
       ],
     },


### PR DESCRIPTION
- Add decay_types to API types, domain select, form types, schema, constants, utils and hooks
- Display decay_types in characteristicsCard substrate section
- Add decay_types to species-request form with correct section grouping
- Reorder species-request sections to match panel order (luminescence first)